### PR TITLE
Fix: Remove artificial 25-piece game over limit

### DIFF
--- a/src/me/blog/justabullet/GameBoardPanel.java
+++ b/src/me/blog/justabullet/GameBoardPanel.java
@@ -340,15 +340,6 @@ public class GameBoardPanel extends JPanel implements ActionListener {
 		curY = BoardHeight - 1 + curBlock.minY();
 		pieceCount++;
 
-		if (pieceCount >= 25) {
-			curBlock.setShape(Tetrominoes.NO_BLOCK);
-			timer.stop();
-			isStarted = false;
-			isGameOver = true;
-			repaint();
-			return;
-		}
-
 		if (!isMovable(curBlock, curX, curY)) {
 			curBlock.setShape(Tetrominoes.NO_BLOCK);
 			timer.stop();


### PR DESCRIPTION
Removes the hardcoded limit that caused the game to end after exactly 25 pieces.
The game now properly ends only when a new tetromino cannot be placed at the top.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)